### PR TITLE
Matching organisations scripts

### DIFF
--- a/match_scripts/README.md
+++ b/match_scripts/README.md
@@ -1,0 +1,47 @@
+# Matching organisations
+Scripts for matching existing organisations from any database to ROR organisations using files.
+
+
+## Description
+
+These scripts allow a user to compare and match his/her organisations to the ROR organisations. The main goal is to find if these organisations exist in the ROR database performing automatic comparisions over two different text fields (organisation name and homepage). 
+
+There are two independent scripts: 1) "matching_name_shortname.py" to compare organisations names (it also uses ROR alternative names) and 2) "matching_urls.py" to match organisation homepages. The ouput of each one of the scripts is a file with the three ROR organisations with the smallest distance from the user input organisation. Distances are based on text comparision using [Levenshtein distance](https://en.wikipedia.org/wiki/Levenshtein_distance). 
+
+After the scripts are run, manually checks are recommendaded to be sure that a real match is among the closest matches. Please, note that scripts can take a long time to run if the whole ROR database is used (>100,000 organisations). Details about a real application of the scripts are in [FAIRsharing blog](https://blog.fairsharing.org/?p=239).
+
+## Usage
+### Name matching
+To run the script matching_name_shortname.py do ```python matching_name_shortname.py ror_file.json file_to_match.csv``` where ror_file.json is the json database dump file obtained from the ROR website and file_to_match.csv is a text file with the user organisations to be matched. In this file, a separator field "|" is used in each line with the following fields:
+- field 1: organisation ID
+- field 2: organisation name
+- field 3: organisation homepage
+
+The output file is "new_org_compare_names.tsv" and uses tab separation ('\t') fields:
+- field 1: smallest distance value between the input organisation and the ROR organisations
+- field 2: organisation ID of the input
+- field 3: organisation name (organisation URL) of the input
+- field 4: smallest distance value between the input organisation and the ROR organisations "+++" ROR ID of the closest ROR organisation "+++(" name of this ROR organisation "+++" URL of this ROR organisation ")"
+- field 5: second smallest distance value between the input organisation and the ROR organisations "+++" ROR ID of the second closest ROR organisation "+++(" name of this ROR organisation "+++" URL of this ROR organisation ")"
+- field 6: third smallest distance value between the input organisation and the ROR organisations "+++" ROR ID of the third closest ROR organisation "+++(" name of this ROR organisation "+++" URL of this ROR organisation ")"
+
+Example to run this script with two small files is: ```python matching_name_shortname.py example/ror_subset.json example/three_organisations.csv``` 
+
+### Homepage matching
+To run the script matching_urls.py do ```python matching_urls.py ror_file.json file_to_match.csv``` where ror_file.json is the json database dump file obtained from the ROR website and file_to_match.csv is a text file with the user organisations to be matched. In this file, a separator field "|" is used in each line with the following fields:
+- field 1: organisation ID
+- field 2: organisation name
+- field 3: organisation homepage
+
+The output file is "new_org_compare_urls.tsv" and uses tab separation ('\t') fields:
+- field 1: smallest distance value between the input organisation and the ROR organisations
+- field 2: organisation ID of the input
+- field 3: organisation name (organisation URL) of the input
+- field 4: smallest distance value between the input organisation and the ROR organisations "+++" ROR ID of the closest ROR organisation "+++(" name of this ROR organisation "+++" URL of this ROR organisation ")"
+- field 5: second smallest distance value between the input organisation and the ROR organisations "+++" ROR ID of the second closest ROR organisation "+++(" name of this ROR organisation "+++" URL of this ROR organisation ")"
+- field 6: third smallest distance value between the input organisation and the ROR organisations "+++" ROR ID of the third closest ROR organisation "+++(" name of this ROR organisation "+++" URL of this ROR organisation ")"
+
+Example to run this script with two small files is: ```python matching_urls.py example/ror_subset.json example/three_organisations.csv``` 
+
+
+Code created by Ramon Granell, ramon.granell@oerc.ox.ac.uk working for [FAIRsharing](https://fairsharing.org/) at Oxford University.

--- a/match_scripts/example/ror_subset.json
+++ b/match_scripts/example/ror_subset.json
@@ -1,0 +1,1475 @@
+[
+    {
+        "ip_addresses": [],
+        "aliases": [],
+        "acronyms": [
+            "ANU"
+        ],
+        "links": [
+            "http://www.anu.edu.au/"
+        ],
+        "country": {
+            "country_code": "AU",
+            "country_name": "Australia"
+        },
+        "name": "Australian National University",
+        "wikipedia_url": "http://en.wikipedia.org/wiki/Australian_National_University",
+        "addresses": [
+            {
+                "lat": -35.2778,
+                "state_code": "AU-ACT",
+                "country_geonames_id": 2077456,
+                "lng": 149.1205,
+                "state": "Australian Capital Territory",
+                "city": "Canberra",
+                "geonames_city": {
+                    "nuts_level2": {
+                        "name": null,
+                        "code": null
+                    },
+                    "geonames_admin2": {
+                        "ascii_name": null,
+                        "id": null,
+                        "name": null,
+                        "code": null
+                    },
+                    "geonames_admin1": {
+                        "ascii_name": "ACT",
+                        "id": 2177478,
+                        "name": "ACT",
+                        "code": "AU.01"
+                    },
+                    "city": "Canberra",
+                    "id": 2172517,
+                    "nuts_level1": {
+                        "name": null,
+                        "code": null
+                    },
+                    "nuts_level3": {
+                        "name": null,
+                        "code": null
+                    },
+                    "license": {
+                        "attribution": "Data from geonames.org under a CC-BY 3.0 license",
+                        "license": "http://creativecommons.org/licenses/by/3.0/"
+                    }
+                },
+                "postcode": null,
+                "primary": false,
+                "line": null
+            }
+        ],
+        "types": [
+            "Education"
+        ],
+        "established": 1946,
+        "relationships": [
+            {
+                "type": "Related",
+                "id": "https://ror.org/041c7s516",
+                "label": "Calvary Hospital"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/04h7nbn38",
+                "label": "Canberra Hospital"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/030jpqj15",
+                "label": "Goulburn Base Hospital"
+            },
+            {
+                "type": "Child",
+                "id": "https://ror.org/006a4jj40",
+                "label": "Mount Stromlo Observatory"
+            }
+        ],
+        "email_address": null,
+        "external_ids": {
+            "Wikidata": {
+                "all": [
+                    "Q127990"
+                ],
+                "preferred": null
+            },
+            "OrgRef": {
+                "all": [
+                    "285106"
+                ],
+                "preferred": null
+            },
+            "ISNI": {
+                "all": [
+                    "0000 0001 2180 7477"
+                ],
+                "preferred": null
+            },
+            "FundRef": {
+                "all": [
+                    "501100000995",
+                    "501100001151",
+                    "100009020"
+                ],
+                "preferred": "501100000995"
+            },
+            "GRID": {
+                "all": "grid.1001.0",
+                "preferred": "grid.1001.0"
+            }
+        },
+        "id": "https://ror.org/019wvm592",
+        "labels": [],
+        "status": "active"
+    },
+    {
+        "ip_addresses": [],
+        "aliases": [],
+        "acronyms": [],
+        "links": [
+            "http://www.monash.edu/"
+        ],
+        "country": {
+            "country_code": "AU",
+            "country_name": "Australia"
+        },
+        "name": "Monash University",
+        "wikipedia_url": "http://en.wikipedia.org/wiki/Monash_University",
+        "addresses": [
+            {
+                "lat": -37.9083,
+                "state_code": "AU-VIC",
+                "country_geonames_id": 2077456,
+                "lng": 145.138,
+                "state": "Victoria",
+                "city": "Melbourne",
+                "geonames_city": {
+                    "nuts_level2": {
+                        "name": null,
+                        "code": null
+                    },
+                    "geonames_admin2": {
+                        "ascii_name": "Melbourne",
+                        "id": 7839805,
+                        "name": "Melbourne",
+                        "code": "AU.07.24600"
+                    },
+                    "geonames_admin1": {
+                        "ascii_name": "Victoria",
+                        "id": 2145234,
+                        "name": "Victoria",
+                        "code": "AU.07"
+                    },
+                    "city": "Melbourne",
+                    "id": 2158177,
+                    "nuts_level1": {
+                        "name": null,
+                        "code": null
+                    },
+                    "nuts_level3": {
+                        "name": null,
+                        "code": null
+                    },
+                    "license": {
+                        "attribution": "Data from geonames.org under a CC-BY 3.0 license",
+                        "license": "http://creativecommons.org/licenses/by/3.0/"
+                    }
+                },
+                "postcode": null,
+                "primary": false,
+                "line": null
+            }
+        ],
+        "types": [
+            "Education"
+        ],
+        "established": 1958,
+        "relationships": [
+            {
+                "type": "Related",
+                "id": "https://ror.org/0484pjq71",
+                "label": "Box Hill Hospital"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/05ktbsm52",
+                "label": "Burnet Institute"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/051b68e86",
+                "label": "Frankston Hospital"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/00aeqjw83",
+                "label": "Jessie McPherson Private Hospital"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/05p96ba03",
+                "label": "Monash Institute of Medical Research"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/036s9kg65",
+                "label": "Monash Medical Centre"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/013m0ac37",
+                "label": "Monash South Africa"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/01wddqe20",
+                "label": "The Alfred Hospital"
+            },
+            {
+                "type": "Child",
+                "id": "https://ror.org/02qa5kg76",
+                "label": "Australian Regenerative Medicine Institute"
+            },
+            {
+                "type": "Child",
+                "id": "https://ror.org/02r3nf527",
+                "label": "IITB-Monash Research Academy"
+            }
+        ],
+        "email_address": null,
+        "external_ids": {
+            "Wikidata": {
+                "all": [
+                    "Q598841"
+                ],
+                "preferred": null
+            },
+            "OrgRef": {
+                "all": [
+                    "149620"
+                ],
+                "preferred": null
+            },
+            "ISNI": {
+                "all": [
+                    "0000 0004 1936 7857"
+                ],
+                "preferred": null
+            },
+            "FundRef": {
+                "all": [
+                    "501100001779",
+                    "501100001144",
+                    "501100007917",
+                    "501100000991",
+                    "501100001198",
+                    "501100006532"
+                ],
+                "preferred": "501100001779"
+            },
+            "GRID": {
+                "all": "grid.1002.3",
+                "preferred": "grid.1002.3"
+            }
+        },
+        "id": "https://ror.org/02bfwt286",
+        "labels": [],
+        "status": "active"
+    },
+    {
+        "ip_addresses": [],
+        "aliases": [],
+        "acronyms": [
+            "UQ"
+        ],
+        "links": [
+            "http://www.uq.edu.au/"
+        ],
+        "country": {
+            "country_code": "AU",
+            "country_name": "Australia"
+        },
+        "name": "University of Queensland",
+        "wikipedia_url": "http://en.wikipedia.org/wiki/University_of_Queensland",
+        "addresses": [
+            {
+                "lat": -27.495964,
+                "state_code": "AU-QLD",
+                "country_geonames_id": 2077456,
+                "lng": 153.009627,
+                "state": "Queensland",
+                "city": "Brisbane",
+                "geonames_city": {
+                    "nuts_level2": {
+                        "name": null,
+                        "code": null
+                    },
+                    "geonames_admin2": {
+                        "ascii_name": "Brisbane",
+                        "id": 7839562,
+                        "name": "Brisbane",
+                        "code": "AU.04.31000"
+                    },
+                    "geonames_admin1": {
+                        "ascii_name": "Queensland",
+                        "id": 2152274,
+                        "name": "Queensland",
+                        "code": "AU.04"
+                    },
+                    "city": "Brisbane",
+                    "id": 2174003,
+                    "nuts_level1": {
+                        "name": null,
+                        "code": null
+                    },
+                    "nuts_level3": {
+                        "name": null,
+                        "code": null
+                    },
+                    "license": {
+                        "attribution": "Data from geonames.org under a CC-BY 3.0 license",
+                        "license": "http://creativecommons.org/licenses/by/3.0/"
+                    }
+                },
+                "postcode": null,
+                "primary": false,
+                "line": null
+            }
+        ],
+        "types": [
+            "Education"
+        ],
+        "established": 1909,
+        "relationships": [
+            {
+                "type": "Related",
+                "id": "https://ror.org/010g47133",
+                "label": "Ipswich Hospital"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/0290qyp66",
+                "label": "Ochsner Medical Center"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/04mqb0968",
+                "label": "Princess Alexandra Hospital"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/05p52kj31",
+                "label": "Royal Brisbane and Women's Hospital"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/03wxseg04",
+                "label": "Terrestrial Ecosystem Research Network"
+            }
+        ],
+        "email_address": "",
+        "external_ids": {
+            "Wikidata": {
+                "all": [
+                    "Q866012"
+                ],
+                "preferred": null
+            },
+            "OrgRef": {
+                "all": [
+                    "192819"
+                ],
+                "preferred": null
+            },
+            "ISNI": {
+                "all": [
+                    "0000 0000 9320 7537"
+                ],
+                "preferred": null
+            },
+            "FundRef": {
+                "all": [
+                    "501100001794",
+                    "501100008407",
+                    "501100005268"
+                ],
+                "preferred": "501100001794"
+            },
+            "GRID": {
+                "all": "grid.1003.2",
+                "preferred": "grid.1003.2"
+            }
+        },
+        "id": "https://ror.org/00rqy9422",
+        "labels": [],
+        "status": "active"
+    },
+    {
+        "ip_addresses": [],
+        "aliases": [],
+        "acronyms": [],
+        "links": [
+            "http://mq.edu.au/"
+        ],
+        "country": {
+            "country_code": "AU",
+            "country_name": "Australia"
+        },
+        "name": "Macquarie University",
+        "wikipedia_url": "http://en.wikipedia.org/wiki/Macquarie_University",
+        "addresses": [
+            {
+                "lat": -33.775259,
+                "state_code": "AU-NSW",
+                "country_geonames_id": 2077456,
+                "lng": 151.112915,
+                "state": "New South Wales",
+                "city": "Sydney",
+                "geonames_city": {
+                    "nuts_level2": {
+                        "name": null,
+                        "code": null
+                    },
+                    "geonames_admin2": {
+                        "ascii_name": null,
+                        "id": null,
+                        "name": null,
+                        "code": null
+                    },
+                    "geonames_admin1": {
+                        "ascii_name": "New South Wales",
+                        "id": 2155400,
+                        "name": "New South Wales",
+                        "code": "AU.02"
+                    },
+                    "city": "Sydney",
+                    "id": 2147714,
+                    "nuts_level1": {
+                        "name": null,
+                        "code": null
+                    },
+                    "nuts_level3": {
+                        "name": null,
+                        "code": null
+                    },
+                    "license": {
+                        "attribution": "Data from geonames.org under a CC-BY 3.0 license",
+                        "license": "http://creativecommons.org/licenses/by/3.0/"
+                    }
+                },
+                "postcode": null,
+                "primary": false,
+                "line": null
+            }
+        ],
+        "types": [
+            "Education"
+        ],
+        "established": 1964,
+        "relationships": [
+            {
+                "type": "Related",
+                "id": "https://ror.org/0402tt118",
+                "label": "Sydney Hospital"
+            }
+        ],
+        "email_address": null,
+        "external_ids": {
+            "Wikidata": {
+                "all": [
+                    "Q741082"
+                ],
+                "preferred": null
+            },
+            "OrgRef": {
+                "all": [
+                    "19735"
+                ],
+                "preferred": null
+            },
+            "ISNI": {
+                "all": [
+                    "0000 0001 2158 5405"
+                ],
+                "preferred": null
+            },
+            "FundRef": {
+                "all": [
+                    "501100001230"
+                ],
+                "preferred": null
+            },
+            "GRID": {
+                "all": "grid.1004.5",
+                "preferred": "grid.1004.5"
+            }
+        },
+        "id": "https://ror.org/01sf06y89",
+        "labels": [],
+        "status": "active"
+    },
+    {
+        "ip_addresses": [],
+        "aliases": [
+            "University of New South Wales"
+        ],
+        "acronyms": [
+            "UNSW"
+        ],
+        "links": [
+            "https://www.unsw.edu.au/"
+        ],
+        "country": {
+            "country_code": "AU",
+            "country_name": "Australia"
+        },
+        "name": "UNSW Sydney",
+        "wikipedia_url": "http://en.wikipedia.org/wiki/University_of_New_South_Wales",
+        "addresses": [
+            {
+                "lat": -33.917731,
+                "state_code": "AU-NSW",
+                "country_geonames_id": 2077456,
+                "lng": 151.230964,
+                "state": "New South Wales",
+                "city": "Sydney",
+                "geonames_city": {
+                    "nuts_level2": {
+                        "name": null,
+                        "code": null
+                    },
+                    "geonames_admin2": {
+                        "ascii_name": null,
+                        "id": null,
+                        "name": null,
+                        "code": null
+                    },
+                    "geonames_admin1": {
+                        "ascii_name": "New South Wales",
+                        "id": 2155400,
+                        "name": "New South Wales",
+                        "code": "AU.02"
+                    },
+                    "city": "Sydney",
+                    "id": 2147714,
+                    "nuts_level1": {
+                        "name": null,
+                        "code": null
+                    },
+                    "nuts_level3": {
+                        "name": null,
+                        "code": null
+                    },
+                    "license": {
+                        "attribution": "Data from geonames.org under a CC-BY 3.0 license",
+                        "license": "http://creativecommons.org/licenses/by/3.0/"
+                    }
+                },
+                "postcode": null,
+                "primary": false,
+                "line": null
+            }
+        ],
+        "types": [
+            "Education"
+        ],
+        "established": 1949,
+        "relationships": [
+            {
+                "type": "Related",
+                "id": "https://ror.org/00qrpt643",
+                "label": "Bankstown Lidcombe Hospital"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/04rfr1008",
+                "label": "Black Dog Institute"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/01x784220",
+                "label": "Children's Cancer Institute Australia"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/04xx5ce35",
+                "label": "Fairfield Hospital"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/023331s46",
+                "label": "George Institute for Global Health"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/03y4rnb63",
+                "label": "Ingham Institute"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/01gn4gb91",
+                "label": "Kenvale College"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/01g7s6g79",
+                "label": "Neuroscience Research Australia"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/022arq532",
+                "label": "Prince of Wales Hospital"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/021cxfs56",
+                "label": "Royal Hospital for Women"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/01dvjey82",
+                "label": "Shellharbour Hospital"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/04p6jw654",
+                "label": "Shoalhaven District Memorial Hospital"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/02pk13h45",
+                "label": "St George Hospital"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/01xcx0382",
+                "label": "Sutherland Hospital"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/02tj04e91",
+                "label": "Sydney Children's Hospital"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/0402tt118",
+                "label": "Sydney Hospital"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/03trvqr13",
+                "label": "Victor Chang Cardiac Research Institute"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/05newpx76",
+                "label": "Wagga Wagga Base Hospital"
+            },
+            {
+                "type": "Child",
+                "id": "https://ror.org/02j5s7g39",
+                "label": "Australian Defence Force Academy"
+            }
+        ],
+        "email_address": null,
+        "external_ids": {
+            "Wikidata": {
+                "all": [
+                    "Q734764"
+                ],
+                "preferred": null
+            },
+            "OrgRef": {
+                "all": [
+                    "146078",
+                    "16766976"
+                ],
+                "preferred": "146078"
+            },
+            "ISNI": {
+                "all": [
+                    "0000 0004 4902 0432"
+                ],
+                "preferred": null
+            },
+            "FundRef": {
+                "all": [
+                    "501100001773",
+                    "501100001143",
+                    "501100007281",
+                    "501100002204",
+                    "501100001156"
+                ],
+                "preferred": "501100001773"
+            },
+            "GRID": {
+                "all": "grid.1005.4",
+                "preferred": "grid.1005.4"
+            }
+        },
+        "id": "https://ror.org/03r8z3t63",
+        "labels": [],
+        "status": "active"
+    },
+    {
+        "ip_addresses": [],
+        "aliases": [
+            "University of Newcastle upon Tyne"
+        ],
+        "acronyms": [],
+        "links": [
+            "http://www.ncl.ac.uk/"
+        ],
+        "country": {
+            "country_code": "GB",
+            "country_name": "United Kingdom"
+        },
+        "name": "Newcastle University",
+        "wikipedia_url": "http://en.wikipedia.org/wiki/Newcastle_University",
+        "addresses": [
+            {
+                "lat": 54.978,
+                "state_code": null,
+                "country_geonames_id": 2635167,
+                "lng": -1.615,
+                "state": null,
+                "city": "Newcastle upon Tyne",
+                "geonames_city": {
+                    "nuts_level2": {
+                        "name": "Northumberland and Tyne and Wear",
+                        "code": "UKC2"
+                    },
+                    "geonames_admin2": {
+                        "ascii_name": "Newcastle upon Tyne",
+                        "id": 3333174,
+                        "name": "Newcastle upon Tyne",
+                        "code": "GB.ENG.I7"
+                    },
+                    "geonames_admin1": {
+                        "ascii_name": "England",
+                        "id": 6269131,
+                        "name": "England",
+                        "code": "GB.ENG"
+                    },
+                    "city": "Newcastle upon Tyne",
+                    "id": 2641673,
+                    "nuts_level1": {
+                        "name": "NORTH EAST (ENGLAND)",
+                        "code": "UKC"
+                    },
+                    "nuts_level3": {
+                        "name": "Tyneside",
+                        "code": "UKC22"
+                    },
+                    "license": {
+                        "attribution": "Data from geonames.org under a CC-BY 3.0 license",
+                        "license": "http://creativecommons.org/licenses/by/3.0/"
+                    }
+                },
+                "postcode": null,
+                "primary": false,
+                "line": null
+            }
+        ],
+        "types": [
+            "Education"
+        ],
+        "established": 1834,
+        "relationships": [
+            {
+                "type": "Related",
+                "id": "https://ror.org/00cdwy346",
+                "label": "Freeman Hospital"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/044m9mw93",
+                "label": "NIHR Newcastle Biomedical Research Centre"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/051qy7v07",
+                "label": "Newcastle Hospitals - Campus for Ageing and Vitality"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/009e9eq52",
+                "label": "Newcastle University Medicine Malaysia"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/00mbfhq81",
+                "label": "Newcastle University Singapore"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/015dyrs73",
+                "label": "Queen Elizabeth Hospital"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/01p19k166",
+                "label": "Royal Victoria Infirmary"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/04qgcgz06",
+                "label": "University Hospital of North Durham"
+            },
+            {
+                "type": "Child",
+                "id": "https://ror.org/047d2d387",
+                "label": "Centre for the Observation and Modelling of Earthquakes, Volcanoes and Tectonics"
+            },
+            {
+                "type": "Child",
+                "id": "https://ror.org/03myjph80",
+                "label": "Wellcome Centre for Mitochondrial Research"
+            }
+        ],
+        "email_address": null,
+        "external_ids": {
+            "Wikidata": {
+                "all": [
+                    "Q837164"
+                ],
+                "preferred": null
+            },
+            "HESA": {
+                "all": [
+                    "0154"
+                ],
+                "preferred": null
+            },
+            "OrgRef": {
+                "all": [
+                    "203338",
+                    "4329975"
+                ],
+                "preferred": "203338"
+            },
+            "FundRef": {
+                "all": [
+                    "501100008406",
+                    "501100000774"
+                ],
+                "preferred": null
+            },
+            "ISNI": {
+                "all": [
+                    "0000 0001 0462 7212"
+                ],
+                "preferred": null
+            },
+            "UKPRN": {
+                "all": [
+                    "10007799"
+                ],
+                "preferred": null
+            },
+            "UCAS": {
+                "all": [
+                    "N21"
+                ],
+                "preferred": null
+            },
+            "GRID": {
+                "all": "grid.1006.7",
+                "preferred": "grid.1006.7"
+            }
+        },
+        "id": "https://ror.org/01kj2bm70",
+        "labels": [],
+        "status": "active"
+    },
+    {
+        "ip_addresses": [],
+        "aliases": [
+            "Wollongong University"
+        ],
+        "acronyms": [
+            "UOW"
+        ],
+        "links": [
+            "https://www.uow.edu.au/index.html"
+        ],
+        "country": {
+            "country_code": "AU",
+            "country_name": "Australia"
+        },
+        "name": "University of Wollongong",
+        "wikipedia_url": "http://en.wikipedia.org/wiki/University_of_Wollongong",
+        "addresses": [
+            {
+                "lat": -34.405147,
+                "state_code": "AU-NSW",
+                "country_geonames_id": 2077456,
+                "lng": 150.878387,
+                "state": "New South Wales",
+                "city": "Wollongong",
+                "geonames_city": {
+                    "nuts_level2": {
+                        "name": null,
+                        "code": null
+                    },
+                    "geonames_admin2": {
+                        "ascii_name": "Wollongong",
+                        "id": 7839791,
+                        "name": "Wollongong",
+                        "code": "AU.02.18450"
+                    },
+                    "geonames_admin1": {
+                        "ascii_name": "New South Wales",
+                        "id": 2155400,
+                        "name": "New South Wales",
+                        "code": "AU.02"
+                    },
+                    "city": "Wollongong",
+                    "id": 2171507,
+                    "nuts_level1": {
+                        "name": null,
+                        "code": null
+                    },
+                    "nuts_level3": {
+                        "name": null,
+                        "code": null
+                    },
+                    "license": {
+                        "attribution": "Data from geonames.org under a CC-BY 3.0 license",
+                        "license": "http://creativecommons.org/licenses/by/3.0/"
+                    }
+                },
+                "postcode": null,
+                "primary": false,
+                "line": null
+            }
+        ],
+        "types": [
+            "Education"
+        ],
+        "established": 1951,
+        "relationships": [
+            {
+                "type": "Related",
+                "id": "https://ror.org/01dvjey82",
+                "label": "Shellharbour Hospital"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/04p6jw654",
+                "label": "Shoalhaven District Memorial Hospital"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/02d0e3p67",
+                "label": "Wollongong Hospital"
+            },
+            {
+                "type": "Child",
+                "id": "https://ror.org/0447ajy94",
+                "label": "University of Wollongong in Dubai"
+            }
+        ],
+        "email_address": null,
+        "external_ids": {
+            "Wikidata": {
+                "all": [
+                    "Q1350021"
+                ],
+                "preferred": null
+            },
+            "OrgRef": {
+                "all": [
+                    "461935"
+                ],
+                "preferred": null
+            },
+            "ISNI": {
+                "all": [
+                    "0000 0004 0486 528X"
+                ],
+                "preferred": null
+            },
+            "FundRef": {
+                "all": [
+                    "501100001777"
+                ],
+                "preferred": null
+            },
+            "GRID": {
+                "all": "grid.1007.6",
+                "preferred": "grid.1007.6"
+            }
+        },
+        "id": "https://ror.org/00jtmb277",
+        "labels": [],
+        "status": "active"
+    },
+    {
+        "ip_addresses": [],
+        "aliases": [
+            "Melbourne University"
+        ],
+        "acronyms": [],
+        "links": [
+            "http://www.unimelb.edu.au/"
+        ],
+        "country": {
+            "country_code": "AU",
+            "country_name": "Australia"
+        },
+        "name": "University of Melbourne",
+        "wikipedia_url": "http://en.wikipedia.org/wiki/University_of_Melbourne",
+        "addresses": [
+            {
+                "lat": -37.797115,
+                "state_code": "AU-VIC",
+                "country_geonames_id": 2077456,
+                "lng": 144.959972,
+                "state": "Victoria",
+                "city": "Melbourne",
+                "geonames_city": {
+                    "nuts_level2": {
+                        "name": null,
+                        "code": null
+                    },
+                    "geonames_admin2": {
+                        "ascii_name": "Melbourne",
+                        "id": 7839805,
+                        "name": "Melbourne",
+                        "code": "AU.07.24600"
+                    },
+                    "geonames_admin1": {
+                        "ascii_name": "Victoria",
+                        "id": 2145234,
+                        "name": "Victoria",
+                        "code": "AU.07"
+                    },
+                    "city": "Melbourne",
+                    "id": 2158177,
+                    "nuts_level1": {
+                        "name": null,
+                        "code": null
+                    },
+                    "nuts_level3": {
+                        "name": null,
+                        "code": null
+                    },
+                    "license": {
+                        "attribution": "Data from geonames.org under a CC-BY 3.0 license",
+                        "license": "http://creativecommons.org/licenses/by/3.0/"
+                    }
+                },
+                "postcode": null,
+                "primary": false,
+                "line": null
+            }
+        ],
+        "types": [
+            "Education"
+        ],
+        "established": 1853,
+        "relationships": [
+            {
+                "type": "Related",
+                "id": "https://ror.org/04s1m4564",
+                "label": "AuScope"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/05dbj6g52",
+                "label": "Austin Health"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/010mv7n52",
+                "label": "Austin Hospital"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/02c3nzd41",
+                "label": "Australian Urban Research Infrastructure Network"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/05e4f1b55",
+                "label": "Bionics Institute"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/05ktbsm52",
+                "label": "Burnet Institute"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/01sqdef20",
+                "label": "Centre for Eye Research Australia"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/02ett6548",
+                "label": "Epworth Hospital"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/00jrpxe15",
+                "label": "Geelong Hospital"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/04z4kmw33",
+                "label": "Melbourne Health"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/041684t28",
+                "label": "Mental Health Research Institute"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/048fyec77",
+                "label": "Murdoch Children's Research Institute"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/05mjmsc11",
+                "label": "Northern Hospital"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/02rktxt32",
+                "label": "Royal Children's Hospital"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/03grnna41",
+                "label": "Royal Women's Hospital"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/001kjn539",
+                "label": "St Vincent's Hospital"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/02k3cxs74",
+                "label": "St Vincents Institute of Medical Research"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/008q4kt04",
+                "label": "The Royal Victorian Eye & Ear Hospital"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/00st91468",
+                "label": "Victorian Comprehensive Cancer Centre"
+            },
+            {
+                "type": "Child",
+                "id": "https://ror.org/016899r71",
+                "label": "Peter Doherty Institute"
+            }
+        ],
+        "email_address": "",
+        "external_ids": {
+            "Wikidata": {
+                "all": [
+                    "Q319078"
+                ],
+                "preferred": null
+            },
+            "OrgRef": {
+                "all": [
+                    "363594",
+                    "47000931",
+                    "3917352",
+                    "1007776",
+                    "6839809",
+                    "6954088"
+                ],
+                "preferred": "363594"
+            },
+            "ISNI": {
+                "all": [
+                    "0000 0001 2179 088X"
+                ],
+                "preferred": null
+            },
+            "FundRef": {
+                "all": [
+                    "501100001782",
+                    "501100007961",
+                    "100008758",
+                    "501100000986",
+                    "501100000987",
+                    "501100001052"
+                ],
+                "preferred": "501100001782"
+            },
+            "GRID": {
+                "all": "grid.1008.9",
+                "preferred": "grid.1008.9"
+            }
+        },
+        "id": "https://ror.org/01ej9dk98",
+        "labels": [],
+        "status": "active"
+    },
+    {
+        "ip_addresses": [],
+        "aliases": [],
+        "acronyms": [
+            "UTAS"
+        ],
+        "links": [
+            "http://www.utas.edu.au/"
+        ],
+        "country": {
+            "country_code": "AU",
+            "country_name": "Australia"
+        },
+        "name": "University of Tasmania",
+        "wikipedia_url": "http://en.wikipedia.org/wiki/University_of_Tasmania",
+        "addresses": [
+            {
+                "lat": -42.902093,
+                "state_code": "AU-TAS",
+                "country_geonames_id": 2077456,
+                "lng": 147.332497,
+                "state": "Tasmania",
+                "city": "Hobart",
+                "geonames_city": {
+                    "nuts_level2": {
+                        "name": null,
+                        "code": null
+                    },
+                    "geonames_admin2": {
+                        "ascii_name": "Hobart",
+                        "id": 7839672,
+                        "name": "Hobart",
+                        "code": "AU.06.62810"
+                    },
+                    "geonames_admin1": {
+                        "ascii_name": "Tasmania",
+                        "id": 2147291,
+                        "name": "Tasmania",
+                        "code": "AU.06"
+                    },
+                    "city": "Hobart",
+                    "id": 2163355,
+                    "nuts_level1": {
+                        "name": null,
+                        "code": null
+                    },
+                    "nuts_level3": {
+                        "name": null,
+                        "code": null
+                    },
+                    "license": {
+                        "attribution": "Data from geonames.org under a CC-BY 3.0 license",
+                        "license": "http://creativecommons.org/licenses/by/3.0/"
+                    }
+                },
+                "postcode": null,
+                "primary": false,
+                "line": null
+            }
+        ],
+        "types": [
+            "Education"
+        ],
+        "established": 1890,
+        "relationships": [
+            {
+                "type": "Related",
+                "id": "https://ror.org/05fv9c840",
+                "label": "Australian Maritime College"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/010x3gp67",
+                "label": "Integrated Marine Observing System"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/04ymr6s03",
+                "label": "Launceston General Hospital"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/031382m70",
+                "label": "Royal Hobart Hospital"
+            }
+        ],
+        "email_address": null,
+        "external_ids": {
+            "Wikidata": {
+                "all": [
+                    "Q962011"
+                ],
+                "preferred": null
+            },
+            "OrgRef": {
+                "all": [
+                    "601288"
+                ],
+                "preferred": null
+            },
+            "ISNI": {
+                "all": [
+                    "0000 0004 1936 826X"
+                ],
+                "preferred": null
+            },
+            "FundRef": {
+                "all": [
+                    "501100001249",
+                    "501100001038"
+                ],
+                "preferred": "501100001249"
+            },
+            "GRID": {
+                "all": "grid.1009.8",
+                "preferred": "grid.1009.8"
+            }
+        },
+        "id": "https://ror.org/01nfmeh72",
+        "labels": [],
+        "status": "active"
+    },
+    {
+        "ip_addresses": [],
+        "aliases": [
+            "Adelaide Uni"
+        ],
+        "acronyms": [],
+        "links": [
+            "http://www.adelaide.edu.au/"
+        ],
+        "country": {
+            "country_code": "AU",
+            "country_name": "Australia"
+        },
+        "name": "University of Adelaide",
+        "wikipedia_url": "http://en.wikipedia.org/wiki/University_of_Adelaide",
+        "addresses": [
+            {
+                "lat": -34.920656,
+                "state_code": "AU-SA",
+                "country_geonames_id": 2077456,
+                "lng": 138.605756,
+                "state": "South Australia",
+                "city": "Adelaide",
+                "geonames_city": {
+                    "nuts_level2": {
+                        "name": null,
+                        "code": null
+                    },
+                    "geonames_admin2": {
+                        "ascii_name": "Adelaide",
+                        "id": 7839644,
+                        "name": "Adelaide",
+                        "code": "AU.05.40070"
+                    },
+                    "geonames_admin1": {
+                        "ascii_name": "South Australia",
+                        "id": 2061327,
+                        "name": "South Australia",
+                        "code": "AU.05"
+                    },
+                    "city": "Adelaide",
+                    "id": 2078025,
+                    "nuts_level1": {
+                        "name": null,
+                        "code": null
+                    },
+                    "nuts_level3": {
+                        "name": null,
+                        "code": null
+                    },
+                    "license": {
+                        "attribution": "Data from geonames.org under a CC-BY 3.0 license",
+                        "license": "http://creativecommons.org/licenses/by/3.0/"
+                    }
+                },
+                "postcode": null,
+                "primary": false,
+                "line": null
+            }
+        ],
+        "types": [
+            "Education"
+        ],
+        "established": 1874,
+        "relationships": [
+            {
+                "type": "Related",
+                "id": "https://ror.org/047kx5j58",
+                "label": "Hanson Institute"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/00pjm1054",
+                "label": "Lyell McEwin Hospital"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/03pa4y709",
+                "label": "Modbury Hospital"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/00carf720",
+                "label": "Royal Adelaide Hospital"
+            },
+            {
+                "type": "Related",
+                "id": "https://ror.org/03kwrfk72",
+                "label": "Women's and Children's Hospital"
+            },
+            {
+                "type": "Child",
+                "id": "https://ror.org/043t7b640",
+                "label": "Freemasons Foundation Centre for Men's Health"
+            }
+        ],
+        "email_address": "",
+        "external_ids": {
+            "Wikidata": {
+                "all": [
+                    "Q15574"
+                ],
+                "preferred": null
+            },
+            "OrgRef": {
+                "all": [
+                    "206748"
+                ],
+                "preferred": null
+            },
+            "ISNI": {
+                "all": [
+                    "0000 0004 1936 7304"
+                ],
+                "preferred": null
+            },
+            "FundRef": {
+                "all": [
+                    "501100001786",
+                    "501100002678",
+                    "501100005887",
+                    "501100007197"
+                ],
+                "preferred": "501100001786"
+            },
+            "GRID": {
+                "all": "grid.1010.0",
+                "preferred": "grid.1010.0"
+            }
+        },
+        "id": "https://ror.org/00892tw58",
+        "labels": [],
+        "status": "active"
+    }
+]

--- a/match_scripts/example/three_organisations.csv
+++ b/match_scripts/example/three_organisations.csv
@@ -1,0 +1,3 @@
+1|Australian National U|http://english.cas.cn/join_us/jobs/201512/t20151204_157107.shtml
+2|1061 Research|http://1061research.com/
+44|Adelaide Uni|http://www.adelaide.edu.au/

--- a/match_scripts/matching_name_shortname.py
+++ b/match_scripts/matching_name_shortname.py
@@ -1,0 +1,190 @@
+import re
+import json
+import numpy as np
+import csv
+import sys
+
+#This script was created by Ramon Granell ramon.granell@oerc.ox.ac.uk to math ROR (https://ror.org/) organisations with FAIRsharing (https://fairsharing.org/) organisations.
+
+#To execute the script: python matching_name_shortname.py ror_file file_to_match where:
+# ror_file is the json dump database file obtained from the ROR website
+# file_to_match is text file using as separator field "|" with the following fields in each line:
+# field 1: organisation ID
+# field 2: organisation name
+# field 3: organisation homepage
+
+#Function copied from https://stackabuse.com/levenshtein-distance-and-text-similarity-in-python/
+def levenshtein(seq1, seq2):
+    size_x = len(seq1) + 1
+    size_y = len(seq2) + 1
+    matrix = np.zeros ((size_x, size_y))
+    for x in range(size_x):
+        matrix [x, 0] = x
+    for y in range(size_y):
+        matrix [0, y] = y
+
+    for x in range(1, size_x):
+        for y in range(1, size_y):
+            if seq1[x-1] == seq2[y-1]:
+                matrix [x,y] = min(
+                    matrix[x-1, y] + 1,
+                    matrix[x-1, y-1],
+                    #matrix[x, y-1] + 1
+                )
+            else:
+                matrix [x,y] = min(
+                    matrix[x-1,y] + 1,
+                    matrix[x-1,y-1] + 1,
+                    matrix[x,y-1] + 1
+                )
+    #print (matrix)
+    return (matrix[size_x - 1, size_y - 1])
+
+nameRorFile = sys.argv[1]
+nameMatchingFile = sys.argv[2]
+
+pattern = re.compile('[^A-Za-z0-9 ]+')
+
+#1 Load the nameMatchingFile
+#pick organisations that are not found after step2
+dbOrgs_analysed= []
+dbOrgs_new= []
+l =0
+
+with open(nameMatchingFile, 'r', encoding='utf8') as f:
+    read_tsv = csv.reader(f, delimiter="|")
+    for line in read_tsv:
+            dbOrg = {}
+            dbOrg['urlFairsharing'] = line[2].strip()
+            dbOrg['name'] = line[1]
+            dbOrg['myName'] = pattern.sub('', dbOrg['name']).lower()
+            dbOrg['lenMyName'] = len(dbOrg['myName'])
+            dbOrg['url'] = line[2]
+            dbOrg['id'] = line[0]
+            dbOrgs_new.append(dbOrg)
+
+
+
+
+n=0
+noURL=0
+parsed_json_aliases = []
+parsed_names = []
+
+with open(nameRorFile, 'r', encoding='utf8') as f:
+    text = f.read()
+    #print(text)
+    parsed_json = json.loads(text)
+
+for i in range(len(parsed_json)):
+    if len(parsed_json[i]['links'])>0:
+        url= parsed_json[i]['links'][0]
+    else:
+        noURL+=1
+        url='NOEXISTINGGGGGGGGGG'
+
+
+    parsed_json[i]['link'] = url
+    parsed_json[i]['myName'] = pattern.sub('', parsed_json[i]['name']).lower()
+    parsed_json[i]['lenMyName'] = len(parsed_json[i]['myName'])
+
+    v = {}
+    v['link'] = parsed_json[i]['link']
+    v['name'] = parsed_json[i]['name']
+    v['myName'] = parsed_json[i]['myName']
+    v['lenMyName'] = parsed_json[i]['lenMyName']
+    v['id'] = parsed_json[i]['id']
+    parsed_names.append(v)
+
+    if len(parsed_json[i]['aliases']) > 0:
+        for j in range(len(parsed_json[i]['aliases'])):
+            t = {}
+            t['link'] = parsed_json[i]['link']
+            t['name'] = parsed_json[i]['name']
+            t['myName'] = pattern.sub('', parsed_json[i]['aliases'][j]).lower()
+            t['id'] = parsed_json[i]['id']
+
+            parsed_json_aliases.append(t)
+
+    if len(parsed_json[i]['labels']) > 0:
+        for j in range(len(parsed_json[i]['labels'])):
+            t = {}
+            t['link'] = parsed_json[i]['link']
+            t['name'] = parsed_json[i]['name']
+            t['myName'] = pattern.sub('', parsed_json[i]['labels'][j]['label']).lower()
+            t['id'] = parsed_json[i]['id']
+
+            parsed_json_aliases.append(t)
+
+    if len(parsed_json[i]['acronyms']) > 0:
+        for j in range(len(parsed_json[i]['acronyms'])):
+            t = {}
+            t['link'] = parsed_json[i]['link']
+            t['name'] = parsed_json[i]['name']
+            t['myName'] = pattern.sub('', parsed_json[i]['acronyms'][j]).lower()
+            t['id'] = parsed_json[i]['id']
+
+            parsed_json_aliases.append(t)
+list_orgs = []
+list_orgs.append(dbOrgs_new)
+num_file = 0
+for orgst in list_orgs:
+    fileToPrint = open("new_org_compare_names.tsv", "w")
+    for orgTocheck in orgst:
+        closestNames = []
+        for i in range(3):
+            elIds = {'id': -1,
+                     'dist': 999999
+                     }
+            closestNames.append(elIds)
+        for i in range(len(parsed_names)):
+            edit_distanceName = levenshtein(orgTocheck['myName'], parsed_names[i]['myName'])
+            if edit_distanceName < closestNames[-1]['dist']:
+                toInsert = 2
+                for r in range(1, -1, -1):
+                    if edit_distanceName > closestNames[r]['dist']:
+                        break
+                    else:
+                        toInsert = r
+                # print(str(toInsert))
+                if toInsert != 2:
+                    for r in range(2, toInsert, -1):
+                        # print(str(r)+str(closestURLs[r]['id']))
+                        closestNames[r]['id'] = closestNames[r - 1]['id']
+                        # print(str(r) + str(closestURLs[r]['id']))
+                        closestNames[r]['dist'] = closestNames[r - 1]['dist']
+                closestNames[toInsert]['dist'] = edit_distanceName
+                closestNames[toInsert]['id'] = i
+        if closestNames[0]['dist'] > 4:
+            for j in range(len(parsed_json_aliases)):
+                edit_distanceName = levenshtein(orgTocheck['myName'], parsed_json_aliases[j]['myName'])
+                if edit_distanceName < closestNames[-1]['dist']:
+                    toInsert = 2
+                    for r in range(1, -1, -1):
+                        if edit_distanceName > closestNames[r]['dist']:
+                            break
+                        else:
+                            toInsert = r
+                    # print(str(toInsert))
+                    if toInsert != 2:
+                        for r in range(2, toInsert, -1):
+                            # print(str(r)+str(closestURLs[r]['id']))
+                            closestNames[r]['id'] = closestNames[r - 1]['id']
+                            # print(str(r) + str(closestURLs[r]['id']))
+                            closestNames[r]['dist'] = closestNames[r - 1]['dist']
+                    closestNames[toInsert]['dist'] = edit_distanceName
+                    closestNames[toInsert]['id'] = -1*j
+        fileToPrint.write(str(closestNames[0]['dist'])+"\t"+str(orgTocheck['id']))
+        fileToPrint.write("\t"+orgTocheck['name']+" ("+orgTocheck['url']+")")
+        for i in range(3):
+            if closestNames[i]['id'] < 0:
+                elem = parsed_json_aliases[-1*closestNames[i]['id']]
+            else:
+                elem = parsed_names[closestNames[i]['id']]
+            #print(elem)
+            fileToPrint.write('\t' + str(closestNames[i]['dist']) + ' +++ ' + str(elem['id']) + '+++ (' + str(
+                elem['name']) + '+++' + str(
+                elem['link']) + ')')
+        fileToPrint.write("\n")
+    num_file+=1
+    fileToPrint.close()

--- a/match_scripts/matching_urls.py
+++ b/match_scripts/matching_urls.py
@@ -1,0 +1,133 @@
+import re
+import json
+import numpy as np
+import csv
+import sys
+
+#This script was created by Ramon Granell ramon.granell@oerc.ox.ac.uk to math ROR (https://ror.org/) organisations with FAIRsharing (https://fairsharing.org/) organisations.
+
+#To execute the script: python matching_urls.py ror_file file_to_match where:
+# ror_file is the json database dump file obtained from the ROR website
+# file_to_match is text file using as separator field "|" with the following fields in each line:
+# field 1: organisation ID
+# field 2: organisation name
+# field 3: organisation homepage
+
+
+
+#Function obtained from https://stackabuse.com/levenshtein-distance-and-text-similarity-in-python/
+def levenshtein(seq1, seq2):
+    size_x = len(seq1) + 1
+    size_y = len(seq2) + 1
+    matrix = np.zeros ((size_x, size_y))
+    for x in range(size_x):
+        matrix [x, 0] = x
+    for y in range(size_y):
+        matrix [0, y] = y
+
+    for x in range(1, size_x):
+        for y in range(1, size_y):
+            if seq1[x-1] == seq2[y-1]:
+                matrix [x,y] = min(
+                    matrix[x-1, y] + 1,
+                    matrix[x-1, y-1],
+                    matrix[x, y-1] + 1
+                )
+            else:
+                matrix [x,y] = min(
+                    matrix[x-1,y] + 1,
+                    matrix[x-1,y-1] + 1,
+                    matrix[x,y-1] + 1
+                )
+    #print (matrix)
+    return (matrix[size_x - 1, size_y - 1])
+
+nameRorFile = sys.argv[1]
+nameMatchingFile = sys.argv[2]
+
+pattern = re.compile('[^A-Za-z0-9 ]+')
+
+#1 Load the nameMatchingFile
+dbOrgs_new= []
+l =0
+
+with open(nameMatchingFile, 'r', encoding='utf8') as f:
+    read_tsv = csv.reader(f, delimiter="|")
+    for line in read_tsv:
+            dbOrg = {}
+            dbOrg['urlFairsharing'] = line[2].strip()
+            dbOrg['name'] = line[1]
+            dbOrg['myName'] = pattern.sub('', dbOrg['name']).lower()
+            dbOrg['lenMyName'] = len(dbOrg['myName'])
+            dbOrg['url'] = line[2]
+            dbOrg['id'] = line[0]
+            dbOrgs_new.append(dbOrg)
+
+n=0
+noURL=0
+parsed_urls = []
+
+with open(nameRorFile, 'r', encoding='utf8') as f:
+    text = f.read()
+    #print(text)
+    parsed_json = json.loads(text)
+
+for i in range(len(parsed_json)):
+    if len(parsed_json[i]['links'])>0:
+        url= parsed_json[i]['links'][0]
+    else:
+        noURL+=1
+        url='NOEXISTING'
+
+
+    parsed_json[i]['link'] = url
+    parsed_json[i]['myName'] = pattern.sub('', parsed_json[i]['name']).lower()
+    parsed_json[i]['lenMyName'] = len(parsed_json[i]['myName'])
+    v = {}
+    v['link'] = parsed_json[i]['link']
+    v['name'] = parsed_json[i]['name']
+    v['myName'] = parsed_json[i]['myName']
+    v['lenMyName'] = parsed_json[i]['lenMyName']
+    v['id'] = parsed_json[i]['id']
+    parsed_urls.append(v)
+
+
+list_orgs = []
+list_orgs.append(dbOrgs_new)
+
+list_file_print = "new_org_compare_urls.tsv"
+for orgst in list_orgs:
+    fileToPrint = open(list_file_print, "w")
+    for orgTocheck in orgst:
+        closestNames = []
+        for i in range(3):
+            elIds = {'id': -1,
+                     'dist': 999999
+                     }
+            closestNames.append(elIds)
+        for i in range(len(parsed_urls)):
+            edit_distanceName = levenshtein(orgTocheck['url'], parsed_urls[i]['link'])
+            if edit_distanceName < closestNames[-1]['dist']:
+                toInsert = 2
+                for r in range(1, -1, -1):
+                    if edit_distanceName > closestNames[r]['dist']:
+                        break
+                    else:
+                        toInsert = r
+                # print(str(toInsert))
+                if toInsert != 2:
+                    for r in range(2, toInsert, -1):
+                        # print(str(r)+str(closestURLs[r]['id']))
+                        closestNames[r]['id'] = closestNames[r - 1]['id']
+                        # print(str(r) + str(closestURLs[r]['id']))
+                        closestNames[r]['dist'] = closestNames[r - 1]['dist']
+                closestNames[toInsert]['dist'] = edit_distanceName
+                closestNames[toInsert]['id'] = i
+        fileToPrint.write(str(closestNames[0]['dist'])+"\t"+"\t"+"https://fairsharing.org/organisations/"+str(orgTocheck['id']))
+        fileToPrint.write("\t"+orgTocheck['name']+" ("+orgTocheck['url']+")")
+        for i in range(3):
+            fileToPrint.write('\t' + str(closestNames[i]['dist']) + ' +++ ' + str(parsed_urls[closestNames[i]['id']]['id']) + '+++ (' + str(
+                parsed_urls[closestNames[i]['id']]['name']) + '+++' + str(
+                parsed_urls[closestNames[i]['id']]['link']) + ')')
+        fileToPrint.write("\n")
+    fileToPrint.close()


### PR DESCRIPTION
I am a developer from [FAIRsharing.org](https://fairsharing.org/) that has been using ROR organisations for a while. We have talk to A. French from ROR that suggested us to add the scripts that we have been using to match [our organisations](https://fairsharing.org/organisations/) to ROR organisations. The code is generic enough to be used with any organisations meanwhile you have their name and/or homepage in a text file. 

It is the first time that I do a PR to any external repository and not sure if the code is documented and organised enough  to be accepted. Feel free to modify anything you consider.